### PR TITLE
Can't use 'import', use 'require'

### DIFF
--- a/eth_transfer.js
+++ b/eth_transfer.js
@@ -4,7 +4,7 @@ const { default_http_options, default_ws_options } = require('./properties');
 const Tx = require('ethereumjs-tx').Transaction;
 const nonce_helper_fn = require('./nonce_helper');
 const Web3WsProvider = require('web3-providers-ws');
-import Big from 'big.js'
+const Big = require('big.js')
 const HDWalletProvider = require("@truffle/hdwallet-provider");
 
 class EthTransfer {

--- a/roks_transfer.js
+++ b/roks_transfer.js
@@ -5,7 +5,7 @@ const contract = require('./contract_abi');
 const nonce_helper_fn = require('./nonce_helper');
 const Web3WsProvider = require('web3-providers-ws');
 const HDWalletProvider = require("@truffle/hdwallet-provider");
-import Big from 'big.js'
+const Big = require('big.js')
 
 class RoksTransfer {
   constructor(


### PR DESCRIPTION
The 'import' statement is OK if source is not compiled into a webpack. When compiled into a webpack, the 'import' statement causes the server to crash.