### PR TITLE
Convert big nums to strings

### DIFF
--- a/eth_transfer.js
+++ b/eth_transfer.js
@@ -128,7 +128,7 @@ class EthTransfer {
       nonce,
       from: this.eth_src_address,
       to: recipient,
-      value: web3.utils.toHex(web3.utils.toWei(amount, 'ether')),
+      value: web3.utils.toHex(web3.utils.toWei(amount.toString(), 'ether').toString()),
       gasPrice: web3.utils.toHex(gasPrice.toString()),
       gasLimit: web3.utils.toHex(this.gas_limit),
     }


### PR DESCRIPTION
This may be causing the docker container to crash. The previous version runs OK in my laptop using "npm start". However, if I put the server in a docker container, it crashes during the API call to ethtransfer. This may fix that crash.
I can't test the revised version without publishing because docker puts the roks_transfer_app in the container. Once it is in the container, it's difficult to edit it.